### PR TITLE
feat: Add CSQuestion, CSAnswer, User entities and Category enum

### DIFF
--- a/src/main/java/com/lgcns/backend/entity/CSAnswer.java
+++ b/src/main/java/com/lgcns/backend/entity/CSAnswer.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Data;
 
@@ -27,10 +28,10 @@ public class CSAnswer {
     private LocalDateTime created_at;
 
     @ManyToOne
-    @Column(nullable = false)
+    @JoinColumn(name = "question_id", nullable = false)
     private CSQuestion csQuestion;
 
     @ManyToOne
-    @Column(nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 }

--- a/src/main/java/com/lgcns/backend/entity/CSAnswer.java
+++ b/src/main/java/com/lgcns/backend/entity/CSAnswer.java
@@ -1,0 +1,36 @@
+package com.lgcns.backend.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Data;
+
+@Entity
+@Data
+public class CSAnswer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String feedback;
+
+    @Column(nullable = false)
+    private LocalDateTime created_at;
+
+    @ManyToOne
+    @Column(nullable = false)
+    private CSQuestion csQuestion;
+
+    @ManyToOne
+    @Column(nullable = false)
+    private User user;
+}

--- a/src/main/java/com/lgcns/backend/entity/CSQuestion.java
+++ b/src/main/java/com/lgcns/backend/entity/CSQuestion.java
@@ -1,0 +1,34 @@
+package com.lgcns.backend.entity;
+
+import java.time.LocalDateTime;
+
+import com.lgcns.backend.type.Category;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Data;
+
+@Entity
+@Data
+public class CSQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+    
+    @Column(nullable = false)
+    private LocalDateTime created_at;
+
+    @Column(nullable = false, unique = true)
+    private String content;
+}
+
+

--- a/src/main/java/com/lgcns/backend/entity/User.java
+++ b/src/main/java/com/lgcns/backend/entity/User.java
@@ -1,0 +1,33 @@
+package com.lgcns.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Data;
+
+@Entity
+@Data
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    // @Column(nullable = false)
+    private String profile_image;
+
+    private String provider;
+}

--- a/src/main/java/com/lgcns/backend/repository/CSAnswerRepository.java
+++ b/src/main/java/com/lgcns/backend/repository/CSAnswerRepository.java
@@ -1,0 +1,10 @@
+package com.lgcns.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lgcns.backend.entity.CSAnswer;
+
+public interface CSAnswerRepository extends JpaRepository<CSAnswer, Long>{
+
+    
+}

--- a/src/main/java/com/lgcns/backend/repository/CSQuestiomRepository.java
+++ b/src/main/java/com/lgcns/backend/repository/CSQuestiomRepository.java
@@ -1,0 +1,9 @@
+package com.lgcns.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lgcns.backend.entity.CSQuestion;
+
+public interface CSQuestiomRepository extends JpaRepository<CSQuestion, Long>{
+    
+}

--- a/src/main/java/com/lgcns/backend/repository/UserRepository.java
+++ b/src/main/java/com/lgcns/backend/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.lgcns.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lgcns.backend.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long>{
+
+    
+}

--- a/src/main/java/com/lgcns/backend/type/Category.java
+++ b/src/main/java/com/lgcns/backend/type/Category.java
@@ -1,0 +1,12 @@
+package com.lgcns.backend.type;
+
+public enum Category {
+    자료구조,
+    알고리즘,
+    컴퓨터구조,
+    운영체제,
+    네트워크,
+    데이터베이스,
+    보안,
+    기타
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
[[ FEATURE ] cs-answer-crud #4 

## 📝작업 내용
- CSQuestion, CSAnswer 엔티티 및 각각의 JPA Repository 생성
- User 엔티티 및 UserRepository 추가
- 질문 주제 분류를 위한 Category enum 정의