### PR TITLE
fix: rename entity fields Java naming style

### DIFF
--- a/src/main/java/com/lgcns/backend/csanswer/domain/CSAnswer.java
+++ b/src/main/java/com/lgcns/backend/csanswer/domain/CSAnswer.java
@@ -27,7 +27,7 @@ public class CSAnswer {
     private String feedback;
 
     @Column(nullable = false)
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 
     @ManyToOne
     @JoinColumn(name = "question_id", nullable = false)

--- a/src/main/java/com/lgcns/backend/csquestion/domain/CSQuestion.java
+++ b/src/main/java/com/lgcns/backend/csquestion/domain/CSQuestion.java
@@ -24,7 +24,7 @@ public class CSQuestion {
     private Category category;
     
     @Column(nullable = false)
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 
     @Column(nullable = false, unique = true)
     private String content;

--- a/src/main/java/com/lgcns/backend/user/domain/User.java
+++ b/src/main/java/com/lgcns/backend/user/domain/User.java
@@ -27,7 +27,7 @@ public class User {
     private String nickname;
 
     // @Column(nullable = false)
-    private String profile_image;
+    private String profileImage;
 
     private String provider;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
---
[ FEATURE ] cs-answer-crud https://github.com/lgcnsCampMprjTeam2/BackEnd/issues/4

## 📝작업 내용
---
User, CSAnswer, CSQuestion 엔티티 필드 Java 네이밍 규칙 카멜케이스로 변경

