### PR TITLE
feat: Add keyword field to CSQuestion entity and AIQuestionResponse DTO

### DIFF
--- a/src/main/java/com/lgcns/backend/csquestion/domain/CSQuestion.java
+++ b/src/main/java/com/lgcns/backend/csquestion/domain/CSQuestion.java
@@ -31,4 +31,7 @@ public class CSQuestion {
 
     @Column(nullable = false, unique = true)
     private String content;
+
+    @Column(unique = true)
+    private String keyword;
 }

--- a/src/main/java/com/lgcns/backend/csquestion/dto/CSQuestionResponse.java
+++ b/src/main/java/com/lgcns/backend/csquestion/dto/CSQuestionResponse.java
@@ -1,10 +1,12 @@
 package com.lgcns.backend.csquestion.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.lgcns.backend.global.domain.Category;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
@@ -15,4 +17,14 @@ public class CSQuestionResponse {
     private Category category;
     private LocalDateTime createdAt;
     private String content;
+
+
+    @Data
+    @Builder
+    public static class AIQuestionResponse {
+        private Category category;
+        private LocalDateTime createdAt;
+        private String content;
+        private String keyword;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

[ FEATURE ] cs-question-ai-create

## 📝작업 내용

- AI 질문 생성 관련 CSQuestion 엔티티 필드 추가 (Keyword 필드 추가)
  - keyword는 CS 질문의 요약본 역할을 수행 (중복 방지용)
- AI 질문 생성 관련 응답 클래스 추가
