### PR TITLE
refactor: move AIRequest and AIResponse to ai package for shared use

### DIFF
--- a/src/main/java/com/lgcns/backend/ai/dto/AIRequest.java
+++ b/src/main/java/com/lgcns/backend/ai/dto/AIRequest.java
@@ -1,4 +1,4 @@
-package com.lgcns.backend.csanswer.dto;
+package com.lgcns.backend.ai.dto;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/lgcns/backend/ai/dto/AIResponse.java
+++ b/src/main/java/com/lgcns/backend/ai/dto/AIResponse.java
@@ -1,4 +1,4 @@
-package com.lgcns.backend.csanswer.dto;
+package com.lgcns.backend.ai.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/lgcns/backend/csanswer/controller/AIFeedbackController.java
+++ b/src/main/java/com/lgcns/backend/csanswer/controller/AIFeedbackController.java
@@ -23,7 +23,7 @@ public class AIFeedbackController {
     private AIFeedbackService aiFeedbackService;
     
     @PostMapping("/api/answers/{answerId}")
-    public ResponseEntity<CustomResponse<AIFeedbackResponse>> postMethodName(
+    public ResponseEntity<CustomResponse<AIFeedbackResponse>> generateAIFeedback(
             @PathVariable Long answerId,
             @AuthenticationPrincipal UserDetails userDetails) {
         

--- a/src/main/java/com/lgcns/backend/csanswer/service/AIFeedbackService.java
+++ b/src/main/java/com/lgcns/backend/csanswer/service/AIFeedbackService.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.http.HttpHeaders;
 
+import com.lgcns.backend.ai.dto.AIRequest;
+import com.lgcns.backend.ai.dto.AIResponse;
+import com.lgcns.backend.ai.dto.AIRequest.OpenAiRequest;
 import com.lgcns.backend.csanswer.domain.CSAnswer;
-import com.lgcns.backend.csanswer.dto.AIRequest;
-import com.lgcns.backend.csanswer.dto.AIRequest.OpenAiRequest;
-import com.lgcns.backend.csanswer.dto.AIResponse;
 import com.lgcns.backend.csanswer.dto.CSAnswerResponse;
 import com.lgcns.backend.csanswer.repository.CSAnswerRepository;
 import com.lgcns.backend.user.domain.User;


### PR DESCRIPTION
## #️⃣연관된 이슈

[[ FEATURE ] cs-answer-crud](https://github.com/lgcnsCampMprjTeam2/BackEnd/issues/4)
[[ FEATURE ] cs-question-ai-create](https://github.com/lgcnsCampMprjTeam2/BackEnd/issues/43)


## 📝작업 내용

- AIRequest와 AIResponse 공통 사용 위해 ai 패키지로 파일 이동 및 import문 수정
